### PR TITLE
projectDir to replace the deprecated baseDir

### DIFF
--- a/modules/module_a.nf
+++ b/modules/module_a.nf
@@ -3,7 +3,7 @@ process PROCESS_1 {
     tag "${name}"
     publishDir "${params.output}/${name}", mode: 'copy'
 
-    conda ("${baseDir}/environments/module_a.yml")
+    conda ("${projectDir}/environments/module_a.yml")
 
     input:
       tuple val(name), path(fastq1), path(fastq2)
@@ -22,7 +22,7 @@ process PROCESS_2 {
     tag "${name}"
     publishDir "${params.output}/${name}", mode: 'copy'
 
-    conda ("${baseDir}/environments/module_a.yml")
+    conda ("${projectDir}/environments/module_a.yml")
 
     input:
       val(name)

--- a/modules/module_b.nf
+++ b/modules/module_b.nf
@@ -3,7 +3,7 @@ process PROCESS_3 {
     label 'process_3'
     publishDir "${params.output}/merged_results", mode: 'copy'
 
-    conda ("${baseDir}/environments/module_b.yml")
+    conda ("${projectDir}/environments/module_b.yml")
 
     input:
       val(input)

--- a/nextflow.config
+++ b/nextflow.config
@@ -91,7 +91,7 @@ params.input_table = false
 params.output = false
 // Here you could specify your minimal reference fasta file
 // that you generated
-params.reference_fasta = "${baseDir}/resources/minigenome_200.fasta"
+params.reference_fasta = "${projectDir}/resources/minigenome_200.fasta"
 
 params.help_message = """
 NF template v${VERSION}


### PR DESCRIPTION
This PR improves compatibility of this template with newer versions of Nextflow.
It replaces the `baseDir` constant by `projectDir`, as it became deprecated since NF version 20.04  (see: https://www.nextflow.io/docs/latest/reference/stdlib.html#constants)
